### PR TITLE
oop-cop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,16 +26,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>ru.l3r8y</groupId>
-  <artifactId>sa-tan</artifactId>
+  <artifactId>oop-cop</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
   <description>The Maven plugin for checking class mutability within your project</description>
-  <name>sa-tan</name>
+  <name>oop-cop</name>
   <url>https://www.l3r8y.ru/sa-tan</url>
   <scm>
-    <connection>scm:git:git@github.com:l3r8yJ/sa-tan.git</connection>
-    <developerConnection>scm:git:ssh://@github.com:l3r8yJ/sa-tan.git</developerConnection>
-    <url>https://github.com/l3r8yJ/sa-tan/tree/master</url>
+    <connection>scm:git:git@github.com:l3r8yJ/oop-cop.git</connection>
+    <developerConnection>scm:git:ssh://@github.com:l3r8yJ/oop-cop.git</developerConnection>
+    <url>https://github.com/l3r8yJ/oop-cop/tree/master</url>
   </scm>
   <developers>
     <developer>
@@ -54,7 +54,7 @@
   </licenses>
   <ciManagement>
     <system>rultor</system>
-    <url>https://www.rultor.com/p/l3r8yJ/sa-tan</url>
+    <url>https://www.rultor.com/p/l3r8yJ/oop-cop</url>
   </ciManagement>
   <properties>
     <java.version>8</java.version>

--- a/src/it/correct/pom.xml
+++ b/src/it/correct/pom.xml
@@ -28,8 +28,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>ru.l3r8y</groupId>
-        <artifactId>oop-cop</artifactId>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
         <version>@project.version@</version>
         <executions>
           <execution>

--- a/src/it/correct/pom.xml
+++ b/src/it/correct/pom.xml
@@ -29,7 +29,7 @@
     <plugins>
       <plugin>
         <groupId>ru.l3r8y</groupId>
-        <artifactId>sa-tan</artifactId>
+        <artifactId>oop-cop</artifactId>
         <version>@project.version@</version>
         <executions>
           <execution>

--- a/src/it/incorrect/pom.xml
+++ b/src/it/incorrect/pom.xml
@@ -52,9 +52,9 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>ru.l3r8y</groupId>
-        <artifactId>oop-cop</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
         <executions>
           <execution>
             <id>integration-test</id>

--- a/src/it/incorrect/pom.xml
+++ b/src/it/incorrect/pom.xml
@@ -53,7 +53,7 @@
     <plugins>
       <plugin>
         <groupId>ru.l3r8y</groupId>
-        <artifactId>sa-tan</artifactId>
+        <artifactId>oop-cop</artifactId>
         <version>1.0-SNAPSHOT</version>
         <executions>
           <execution>

--- a/src/it/long-class-name/pom.xml
+++ b/src/it/long-class-name/pom.xml
@@ -52,9 +52,9 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>ru.l3r8y</groupId>
-        <artifactId>oop-cop</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
         <executions>
           <execution>
             <id>integration-test</id>

--- a/src/it/long-class-name/pom.xml
+++ b/src/it/long-class-name/pom.xml
@@ -53,7 +53,7 @@
     <plugins>
       <plugin>
         <groupId>ru.l3r8y</groupId>
-        <artifactId>sa-tan</artifactId>
+        <artifactId>oop-cop</artifactId>
         <version>1.0-SNAPSHOT</version>
         <executions>
           <execution>

--- a/src/main/java/ru/l3r8y/ValidateMojo.java
+++ b/src/main/java/ru/l3r8y/ValidateMojo.java
@@ -74,7 +74,6 @@ public final class ValidateMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoFailureException {
-        this.getLog().info("Running Satan plugin...");
         final Path start = Paths.get(this.project.getCompileSourceRoots().get(0));
         final List<Complaint> complaints = new ArrayList<>(0);
         complaints.addAll(new CompositeMethodsContainsAssigment(start).complaints());


### PR DESCRIPTION
closes #91

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the project configuration and code to rename the artifact from "sa-tan" to "oop-cop".

### Detailed summary
- Renamed artifactId from "sa-tan" to "oop-cop" in pom.xml files.
- Updated SCM URLs in pom.xml files to point to the new repository "oop-cop".
- Removed a log statement in ValidateMojo.java.
- Updated the name and URL in pom.xml to reflect the new artifact name "oop-cop".
- Updated the URL in ciManagement section of pom.xml to point to the new repository "oop-cop".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->