### PR TITLE
to oop cop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <nexus-staging.version>1.6.13</nexus-staging.version>
     <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
     <qulice-maven-plugin.version>0.22.0</qulice-maven-plugin.version>
-    <sa-tan.version>0.1.5</sa-tan.version>
+    <oop-cop.version>0.1.6</oop-cop.version>
   </properties>
   <dependencies>
     <dependency>
@@ -340,8 +340,8 @@
           </plugin>
           <plugin>
             <groupId>ru.l3r8y</groupId>
-            <artifactId>sa-tan</artifactId>
-            <version>${sa-tan.version}</version>
+            <artifactId>oop-cop</artifactId>
+            <version>${oop-cop.version}</version>
             <executions>
               <execution>
                 <goals>
@@ -349,6 +349,9 @@
                 </goals>
               </execution>
             </executions>
+            <configuration>
+              <maxClassNameLen>20</maxClassNameLen>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/src/main/java/ru/l3r8y/ValidateMojo.java
+++ b/src/main/java/ru/l3r8y/ValidateMojo.java
@@ -34,9 +34,9 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import ru.l3r8y.complaint.CompoundComplaint;
-import ru.l3r8y.rule.CompositeErNamedClass;
-import ru.l3r8y.rule.CompositeLongClassName;
-import ru.l3r8y.rule.CompositeMethodsContainsAssigment;
+import ru.l3r8y.rule.AssigmentCheck;
+import ru.l3r8y.rule.CompositeClassName;
+import ru.l3r8y.rule.CompositeErNamed;
 
 /**
  * It's a Maven plugin that runs a set of rules against the source code of the
@@ -76,10 +76,10 @@ public final class ValidateMojo extends AbstractMojo {
     public void execute() throws MojoFailureException {
         final Path start = Paths.get(this.project.getCompileSourceRoots().get(0));
         final List<Complaint> complaints = new ArrayList<>(0);
-        complaints.addAll(new CompositeMethodsContainsAssigment(start).complaints());
-        complaints.addAll(new CompositeErNamedClass(start).complaints());
+        complaints.addAll(new AssigmentCheck(start).complaints());
+        complaints.addAll(new CompositeErNamed(start).complaints());
         complaints.addAll(
-            new CompositeLongClassName(
+            new CompositeClassName(
                 start, this.maxClassNameLen
             ).complaints()
         );

--- a/src/main/java/ru/l3r8y/complaint/WrongClassNaming.java
+++ b/src/main/java/ru/l3r8y/complaint/WrongClassNaming.java
@@ -21,37 +21,37 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 package ru.l3r8y.complaint;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import ru.l3r8y.ClassName;
 import ru.l3r8y.Complaint;
-import ru.l3r8y.Method;
 
 /**
- * Complaint about wrong method signature.
+ * Complaint for naming issues.
  *
- * @since 0.1.0
+ * @since 0.1.6
  */
-@AllArgsConstructor
-public class WrongMethodSignatureComplaint implements Complaint {
+@RequiredArgsConstructor
+public final class WrongClassNaming implements Complaint {
 
     /**
-     * The method.
+     * Class with bad naming.
      */
-    private final Method method;
+    private final ClassName clazz;
 
     /**
-     * The explanation of what was wrong.
+     * The explanation.
      */
     private final String explanation;
 
     @Override
-    public final String message() {
+    public String message() {
         return String.format(
-            "'%s': Method '%s#%s' has wrong method signature, because %s",
-            this.method.path(),
-            this.method.className(),
-            this.method.name(),
+            "'%s': Class '%s' has bad naming, %s\n",
+            this.clazz.path().toString(),
+            this.clazz.value(),
             this.explanation
         );
     }

--- a/src/main/java/ru/l3r8y/complaint/WrongMethodSignature.java
+++ b/src/main/java/ru/l3r8y/complaint/WrongMethodSignature.java
@@ -21,37 +21,37 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 package ru.l3r8y.complaint;
 
-import lombok.RequiredArgsConstructor;
-import ru.l3r8y.ClassName;
+import lombok.AllArgsConstructor;
 import ru.l3r8y.Complaint;
+import ru.l3r8y.Method;
 
 /**
- * Complaint for naming issues.
+ * Complaint about wrong method signature.
  *
- * @since 0.1.6
+ * @since 0.1.0
  */
-@RequiredArgsConstructor
-public final class WrongClassNamingComplaint implements Complaint {
+@AllArgsConstructor
+public class WrongMethodSignature implements Complaint {
 
     /**
-     * Class with bad naming.
+     * The method.
      */
-    private final ClassName clazz;
+    private final Method method;
 
     /**
-     * The explanation.
+     * The explanation of what was wrong.
      */
     private final String explanation;
 
     @Override
-    public String message() {
+    public final String message() {
         return String.format(
-            "'%s': Class '%s' has bad naming, %s\n",
-            this.clazz.path().toString(),
-            this.clazz.value(),
+            "'%s': Method '%s#%s' has wrong method signature, because %s",
+            this.method.path(),
+            this.method.className(),
+            this.method.name(),
             this.explanation
         );
     }

--- a/src/main/java/ru/l3r8y/rule/CompositeClassName.java
+++ b/src/main/java/ru/l3r8y/rule/CompositeClassName.java
@@ -32,27 +32,32 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import ru.l3r8y.ClassName;
 import ru.l3r8y.Complaint;
-import ru.l3r8y.Method;
 import ru.l3r8y.Rule;
-import ru.l3r8y.parser.ClassMethods;
+import ru.l3r8y.parser.ClassNames;
 
 /**
- * It's a rule that matches a path that is composed of other rules.
+ * Composite Long Class Name.
  *
- * @since 0.1.0
+ * @since 0.2.0
  */
-@AllArgsConstructor
-public final class CompositeMethodsContainsAssigment implements Rule {
+@RequiredArgsConstructor
+public final class CompositeClassName implements Rule {
 
     /**
-     * A path to the root of the project.
+     * Path to start.
      */
     private final Path start;
 
+    /**
+     * Length to pass.
+     */
+    private final int fine;
+
     @Override
-    public List<Complaint> complaints() {
+    public Collection<Complaint> complaints() {
         final List<Complaint> accum;
         if (Files.exists(this.start)) {
             try (Stream<Path> files = Files.walk(this.start)) {
@@ -60,9 +65,9 @@ public final class CompositeMethodsContainsAssigment implements Rule {
                     .filter(Files::exists)
                     .filter(Files::isRegularFile)
                     .filter(p -> p.toString().endsWith(".java"))
-                    .map(ClassMethods::new)
-                    .map(ClassMethods::all)
-                    .map(CompositeMethodsContainsAssigment::checkAssigment)
+                    .map(ClassNames::new)
+                    .map(ClassNames::all)
+                    .map(this::checkLongName)
                     .flatMap(Collection::stream)
                     .collect(Collectors.toList());
             } catch (final IOException ex) {
@@ -81,20 +86,23 @@ public final class CompositeMethodsContainsAssigment implements Rule {
     }
 
     /**
-     * It takes a collection of methods, and returns a collection of complaints.
-     *
-     * @param methods A collection of methods to check
-     * @return A collection of complaints
+     * Checks long class name in a collection of names.
+     * @param names Class names
+     * @return Complaints.
+     * @todo #81 Introduce new class from #checkLongName private method.
+     *  we should introduce new reusable class from private method
+     *  #checkLongName.
+     *  Don't forget to remove this puzzle.
      */
-    private static Collection<Complaint> checkAssigment(final Collection<Method> methods) {
+    private Collection<Complaint> checkLongName(final Collection<ClassName> names) {
         final Collection<Complaint> result;
-        if (methods.isEmpty()) {
+        if (names.isEmpty()) {
             result = Collections.emptyList();
         } else {
             final Collection<Complaint> cmps = new ArrayList<>(0);
-            methods.stream()
-                .map(MethodContainsAssigment::new)
-                .map(MethodContainsAssigment::complaints)
+            names.stream()
+                .map(cl -> new LongClassNameCheck(cl, this.fine))
+                .map(LongClassNameCheck::complaints)
                 .forEach(cmps::addAll);
             result = cmps;
         }

--- a/src/main/java/ru/l3r8y/rule/CompositeErNamed.java
+++ b/src/main/java/ru/l3r8y/rule/CompositeErNamed.java
@@ -52,7 +52,7 @@ import ru.l3r8y.parser.ClassNames;
  * @since 0.1.6
  */
 @RequiredArgsConstructor
-public final class CompositeErNamedClass implements Rule {
+public final class CompositeErNamed implements Rule {
 
     /**
      * The start path.
@@ -70,7 +70,7 @@ public final class CompositeErNamedClass implements Rule {
                     .filter(p -> p.toString().endsWith(".java"))
                     .map(ClassNames::new)
                     .map(ClassNames::all)
-                    .map(CompositeErNamedClass::checkWithErNamedRule)
+                    .map(CompositeErNamed::checkWithErNamedRule)
                     .flatMap(Collection::stream)
                     .collect(Collectors.toList());
             } catch (final IOException ex) {

--- a/src/main/java/ru/l3r8y/rule/ErNamedClass.java
+++ b/src/main/java/ru/l3r8y/rule/ErNamedClass.java
@@ -29,7 +29,7 @@ import lombok.RequiredArgsConstructor;
 import ru.l3r8y.ClassName;
 import ru.l3r8y.Complaint;
 import ru.l3r8y.Rule;
-import ru.l3r8y.complaint.WrongClassNamingComplaint;
+import ru.l3r8y.complaint.WrongClassNaming;
 
 /*
  * @todo #35 Annotations to skip rule.
@@ -53,7 +53,7 @@ public final class ErNamedClass implements Rule {
     public Collection<Complaint> complaints() {
         return new ConditionRule(
             this::isEndsWithEr,
-            new WrongClassNamingComplaint(this.name, "class ends with '-er' suffix")
+            new WrongClassNaming(this.name, "class ends with '-er' suffix")
         ).complaints();
     }
 

--- a/src/main/java/ru/l3r8y/rule/LongClassNameCheck.java
+++ b/src/main/java/ru/l3r8y/rule/LongClassNameCheck.java
@@ -28,7 +28,7 @@ import lombok.RequiredArgsConstructor;
 import ru.l3r8y.ClassName;
 import ru.l3r8y.Complaint;
 import ru.l3r8y.Rule;
-import ru.l3r8y.complaint.WrongClassNamingComplaint;
+import ru.l3r8y.complaint.WrongClassNaming;
 
 /**
  * Check for Long class name.
@@ -52,7 +52,7 @@ public final class LongClassNameCheck implements Rule {
     public Collection<Complaint> complaints() {
         return new ConditionRule(
             this::longerThanOk,
-            new WrongClassNamingComplaint(
+            new WrongClassNaming(
                 this.name,
                 // @checkstyle StringLiteralsConcatenationCheck (4 lines).
                 String.format(

--- a/src/main/java/ru/l3r8y/rule/MethodChangesState.java
+++ b/src/main/java/ru/l3r8y/rule/MethodChangesState.java
@@ -33,7 +33,7 @@ import lombok.AllArgsConstructor;
 import ru.l3r8y.Complaint;
 import ru.l3r8y.Method;
 import ru.l3r8y.Rule;
-import ru.l3r8y.complaint.WrongMethodSignatureComplaint;
+import ru.l3r8y.complaint.WrongMethodSignature;
 
 /**
  * It checks if a method contains an assignment.
@@ -41,7 +41,7 @@ import ru.l3r8y.complaint.WrongMethodSignatureComplaint;
  * @since 0.1.0
  */
 @AllArgsConstructor
-public final class MethodContainsAssigment implements Rule {
+public final class MethodChangesState implements Rule {
 
     /**
      * Pattern which matches this assignments.
@@ -60,7 +60,7 @@ public final class MethodContainsAssigment implements Rule {
     public Collection<Complaint> complaints() {
         return new ConditionRule(
             this::containsAssigment,
-            new WrongMethodSignatureComplaint(
+            new WrongMethodSignature(
                 this.method,
                 "method body contains an assignment, setters violates OOP principles"
             )
@@ -73,6 +73,6 @@ public final class MethodContainsAssigment implements Rule {
      * @return A boolean value.
      */
     private boolean containsAssigment() {
-        return MethodContainsAssigment.PATTERN.matcher(this.method.body()).find();
+        return MethodChangesState.PATTERN.matcher(this.method.body()).find();
     }
 }

--- a/src/test/java/ru/l3r8y/complaint/CompoundComplaintTest.java
+++ b/src/test/java/ru/l3r8y/complaint/CompoundComplaintTest.java
@@ -50,7 +50,7 @@ class CompoundComplaintTest {
     void mergesMessages() {
         final Collection<Complaint> complaints = Collections.nCopies(
             5,
-            new WrongMethodSignatureComplaint(
+            new WrongMethodSignature(
                 new ParsedMethod(
                     "ClassName",
                     "myCoolMethod()",

--- a/src/test/java/ru/l3r8y/rule/ErNamedClassTest.java
+++ b/src/test/java/ru/l3r8y/rule/ErNamedClassTest.java
@@ -44,7 +44,7 @@ final class ErNamedClassTest {
     void failsWithErOnEnd(final Path clazz) {
         MatcherAssert.assertThat(
             "Will fail with bad name",
-            new CompositeErNamedClass(clazz).complaints(),
+            new CompositeErNamed(clazz).complaints(),
             Matchers.not(Matchers.empty())
         );
     }
@@ -54,7 +54,7 @@ final class ErNamedClassTest {
     void passesWhenNameIsFine(final Path clazz) {
         MatcherAssert.assertThat(
             "Ok when class name without 'er' suffix",
-            new CompositeErNamedClass(clazz).complaints(),
+            new CompositeErNamed(clazz).complaints(),
             Matchers.empty()
         );
     }

--- a/src/test/java/ru/l3r8y/rule/LongClassNameCheckTest.java
+++ b/src/test/java/ru/l3r8y/rule/LongClassNameCheckTest.java
@@ -43,7 +43,7 @@ final class LongClassNameCheckTest {
     void failsWithErOnEnd(final Path clazz) {
         MatcherAssert.assertThat(
             "Build is not failed as expected",
-            new CompositeLongClassName(clazz, 15).complaints(),
+            new CompositeClassName(clazz, 15).complaints(),
             Matchers.not(Matchers.empty())
         );
     }
@@ -53,7 +53,7 @@ final class LongClassNameCheckTest {
     void passesWhenNameIsFine(final Path clazz) {
         MatcherAssert.assertThat(
             "Build is not successed as expected",
-            new CompositeLongClassName(clazz, 13).complaints(),
+            new CompositeClassName(clazz, 13).complaints(),
             Matchers.empty()
         );
     }

--- a/src/test/java/ru/l3r8y/rule/MethodChangesStateTest.java
+++ b/src/test/java/ru/l3r8y/rule/MethodChangesStateTest.java
@@ -39,18 +39,18 @@ import ru.l3r8y.extensions.Marked;
 import ru.l3r8y.extensions.ValidClass;
 
 /**
- * Test case for {@link MethodContainsAssigment}.
+ * Test case for {@link MethodChangesState}.
  *
  * @since 0.1.0
  */
-final class MethodContainsAssigmentTest {
+final class MethodChangesStateTest {
 
     @Test
     @ExtendWith(InvalidClass.class)
     void failsWhenInvalid(final Path clazz) {
         MatcherAssert.assertThat(
             "InvalidClass contains 1 broken method",
-            new CompositeMethodsContainsAssigment(clazz).complaints(),
+            new AssigmentCheck(clazz).complaints(),
             Matchers.hasSize(1)
         );
     }
@@ -61,7 +61,7 @@ final class MethodContainsAssigmentTest {
     void failsWithoutThisKeyword(final Path clazz) {
         MatcherAssert.assertThat(
             "CaseWithoutThis contains 1 broken method",
-            new CompositeMethodsContainsAssigment(clazz).complaints(),
+            new AssigmentCheck(clazz).complaints(),
             Matchers.hasSize(1)
         );
     }
@@ -71,7 +71,7 @@ final class MethodContainsAssigmentTest {
     void passesWhenValid(final Path clazz) {
         MatcherAssert.assertThat(
             "ValidClass contains no broken methods",
-            new CompositeMethodsContainsAssigment(clazz).complaints(),
+            new AssigmentCheck(clazz).complaints(),
             Matchers.empty()
         );
     }
@@ -81,7 +81,7 @@ final class MethodContainsAssigmentTest {
     void passesWhenMutableMarked(final Path clazz) {
         MatcherAssert.assertThat(
             "Marked class wasn't checked",
-            new CompositeMethodsContainsAssigment(clazz).complaints(),
+            new AssigmentCheck(clazz).complaints(),
             Matchers.empty()
         );
     }


### PR DESCRIPTION
closes #103 

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on refactoring class and method names in the codebase to improve clarity and consistency.

### Detailed summary:
- Renamed `WrongMethodSignatureComplaint` to `WrongMethodSignature`
- Renamed `CompositeLongClassName` to `CompositeClassName`
- Renamed `WrongClassNamingComplaint` to `WrongClassNaming`
- Renamed `CompositeErNamedClass` to `CompositeErNamed`
- Renamed `CompositeMethodsContainsAssigment` to `AssigmentCheck`
- Updated Maven plugin configuration to use `oop-cop` version 0.1.6
- Updated dependencies and plugin versions in `pom.xml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->