### PR TITLE
feat(#106): Use Concrete Version in README

### DIFF
--- a/.github/workflows/up.yaml
+++ b/.github/workflows/up.yaml
@@ -1,0 +1,28 @@
+---
+name: up
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+concurrency:
+  group: up-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  up:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - run: |-
+          git fetch --tags --force && \
+          latest=$(git tag --sort=creatordate | tail -1) && \
+          sed -E -i "s/<version>[^<]+/<version>${latest}/g" README.md
+      - uses: peter-evans/create-pull-request@v5
+        with:
+          branch: version-up
+          commit-message: 'chore: update the plugin version in README file'
+          delete-branch: true
+          title: 'chore: New Version'
+          assignees: l3r8yJ
+          base: master

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Maven:
     <plugin>
       <groupId>ru.l3r8y</groupId>
       <artifactId>oop-cop</artifactId>
+      <version>0.1.6</version>
       <executions>
         <execution>
           <goals>


### PR DESCRIPTION
1. Add concrete version of the plugin to README (`0.1.6`)
2. Add the script that will automatically update the version in README.

Closes: #106


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Added version `0.1.6` to `README.md` file.
- Added a new GitHub Actions workflow file `up.yaml`.
- The workflow triggers on `push` to `master` branch or any tag.
- The workflow runs on `ubuntu-22.04` environment.
- The workflow fetches tags and updates the version in `README.md`.
- The workflow creates a pull request to update the plugin version in the README file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->