### PR TITLE
Suppressions for checks, more unit tests

### DIFF
--- a/src/it/correct/pom.xml
+++ b/src/it/correct/pom.xml
@@ -37,6 +37,9 @@
             <goals>
               <goal>search</goal>
             </goals>
+            <configuration>
+              <maxClassNameLen>12</maxClassNameLen>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/src/it/correct/src/main/java/VeryLongClassName.java
+++ b/src/it/correct/src/main/java/VeryLongClassName.java
@@ -1,0 +1,6 @@
+/**
+ * @since 0.3.6
+ */
+@SuppressWarnings("OOP.LongClassNameCheck")
+public class VeryLongClassName {
+}

--- a/src/main/java/ru/l3r8y/parser/ClassMethods.java
+++ b/src/main/java/ru/l3r8y/parser/ClassMethods.java
@@ -34,7 +34,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
 import lombok.AllArgsConstructor;
 import org.cactoos.list.ListOf;
 import ru.l3r8y.Method;

--- a/src/main/java/ru/l3r8y/parser/ClassMethods.java
+++ b/src/main/java/ru/l3r8y/parser/ClassMethods.java
@@ -33,7 +33,10 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+
 import lombok.AllArgsConstructor;
+import org.cactoos.list.ListOf;
 import ru.l3r8y.Method;
 import ru.l3r8y.Methods;
 
@@ -86,10 +89,20 @@ public final class ClassMethods implements Methods {
         if (clazz instanceof ClassOrInterfaceDeclaration) {
             final ClassOrInterfaceDeclaration declaration = ClassOrInterfaceDeclaration.class
                 .cast(clazz);
+            final List<String> suppressed = new SuppressedChecks(declaration).value();
+            if (suppressed.isEmpty()) {
+                this.fromNodeToParsedMethod(
+                    methods,
+                    (ClassOrInterfaceDeclaration) clazz
+                );
+            }
             if (
                 !new IsSuppressed(
-                    new SuppressedChecks(declaration),
-                    "MutableStateCheck"
+                    suppressed,
+                    new ListOf<>(
+                        "MutableStateCheck",
+                        "ErSuffixCheck"
+                    )
                 ).value()
             ) {
                 this.fromNodeToParsedMethod(

--- a/src/main/java/ru/l3r8y/parser/ClassMethods.java
+++ b/src/main/java/ru/l3r8y/parser/ClassMethods.java
@@ -78,6 +78,15 @@ public final class ClassMethods implements Methods {
         }
     }
 
+    /*
+     * @todo #85 Make new class instead.
+     *   Let's make a new class that will do the same
+     *   what we are doing with class names but with methods.
+     *   Don't forget to remove this puzzle.
+     * @todo #85 Resolve all available checks into one list.
+     *   Let's merge all checks we got from ClassNames and here,
+     *   ClassMethods. Merge them and resolve.
+     */
     /**
      * If the node is a class, then process it.
      *

--- a/src/main/java/ru/l3r8y/parser/ClassNames.java
+++ b/src/main/java/ru/l3r8y/parser/ClassNames.java
@@ -64,10 +64,11 @@ public final class ClassNames implements Names {
                                 new Default(this.accum, this.path),
                                 new ListOf<>(
                                     /*
-                                     * @todo #85:90min Fetch check names from rule/*
-                                     *   package (or check/*). Instead of hard-coding,
-                                     *   we should fetch the ruleset from related package.
-                                     *   Don't forget to remove this puzzle.
+                                     * @todo #85:90min Fetch check names
+                                     *  from rule/* package (or check/*).
+                                     *  Instead of hard-coding, we should fetch
+                                     *  the ruleset from related package.
+                                     *  Don't forget to remove this puzzle.
                                      */
                                     "ErSuffixCheck",
                                     "MutableStateCheck",

--- a/src/main/java/ru/l3r8y/parser/ClassNames.java
+++ b/src/main/java/ru/l3r8y/parser/ClassNames.java
@@ -24,7 +24,6 @@
 package ru.l3r8y.parser;
 
 import com.github.javaparser.StaticJavaParser;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -64,6 +63,12 @@ public final class ClassNames implements Names {
                             new IgnoresSuppressed(
                                 new Default(this.accum, this.path),
                                 new ListOf<>(
+                                    /*
+                                     * @todo #85:90min Fetch check names from rule/*
+                                     *   package (or check/*). Instead of hard-coding,
+                                     *   we should fetch the ruleset from related package.
+                                     *   Don't forget to remove this puzzle.
+                                     */
                                     "ErSuffixCheck",
                                     "MutableStateCheck",
                                     "LongClassNameCheck"

--- a/src/main/java/ru/l3r8y/parser/ClassNames.java
+++ b/src/main/java/ru/l3r8y/parser/ClassNames.java
@@ -52,6 +52,7 @@ public final class ClassNames implements Names {
      */
     private final Collection<ClassName> accum = new ArrayList<>(0);
 
+    // @checkstyle MethodBodyCommentsCheck (25 lines)
     @Override
     public Collection<ClassName> all() {
         try {

--- a/src/main/java/ru/l3r8y/parser/Code.java
+++ b/src/main/java/ru/l3r8y/parser/Code.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023. Ivanchuck Ivan.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package ru.l3r8y.parser;
 
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;

--- a/src/main/java/ru/l3r8y/parser/Code.java
+++ b/src/main/java/ru/l3r8y/parser/Code.java
@@ -33,7 +33,7 @@ import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 public interface Code {
 
     /**
-     * Add class to analyze
+     * Add class to analyze.
      *
      * @param declaration Java class declaration to add
      */

--- a/src/main/java/ru/l3r8y/parser/Code.java
+++ b/src/main/java/ru/l3r8y/parser/Code.java
@@ -38,4 +38,5 @@ public interface Code {
      * @param declaration Java class declaration to add
      */
     void add(ClassOrInterfaceDeclaration declaration);
+
 }

--- a/src/main/java/ru/l3r8y/parser/Code.java
+++ b/src/main/java/ru/l3r8y/parser/Code.java
@@ -1,0 +1,18 @@
+package ru.l3r8y.parser;
+
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+
+/**
+ * Code to analyze.
+ *
+ * @since 0.3.6
+ */
+public interface Code {
+
+    /**
+     * Add class to analyze
+     *
+     * @param declaration Java class declaration to add
+     */
+    void add(ClassOrInterfaceDeclaration declaration);
+}

--- a/src/main/java/ru/l3r8y/parser/CodeClass.java
+++ b/src/main/java/ru/l3r8y/parser/CodeClass.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023. Ivanchuck Ivan.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package ru.l3r8y.parser;
 
 /**

--- a/src/main/java/ru/l3r8y/parser/CodeClass.java
+++ b/src/main/java/ru/l3r8y/parser/CodeClass.java
@@ -34,4 +34,5 @@ public interface CodeClass {
      * Declare code class.
      */
     void declare();
+
 }

--- a/src/main/java/ru/l3r8y/parser/CodeClass.java
+++ b/src/main/java/ru/l3r8y/parser/CodeClass.java
@@ -1,0 +1,14 @@
+package ru.l3r8y.parser;
+
+/**
+ * Code class.
+ *
+ * @since 0.3.6
+ */
+public interface CodeClass {
+
+    /**
+     * Declare code class.
+     */
+    void declare();
+}

--- a/src/main/java/ru/l3r8y/parser/Declaration.java
+++ b/src/main/java/ru/l3r8y/parser/Declaration.java
@@ -1,0 +1,40 @@
+package ru.l3r8y.parser;
+
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+
+/**
+ * Class declaration.
+ *
+ * @since 0.3.6
+ */
+public final class Declaration implements CodeClass {
+
+    /**
+     * Origin.
+     */
+    private final Code code;
+
+    /**
+     * Class.
+     */
+    private final Node clazz;
+
+    /**
+     * Ctor.
+     *
+     * @param cd code
+     * @param clzz class
+     */
+    public Declaration(final Code cd, final Node clzz) {
+        this.code = cd;
+        this.clazz = clzz;
+    }
+
+    @Override
+    public void declare() {
+        if (this.clazz instanceof ClassOrInterfaceDeclaration) {
+            this.code.add((ClassOrInterfaceDeclaration) this.clazz);
+        }
+    }
+}

--- a/src/main/java/ru/l3r8y/parser/Declaration.java
+++ b/src/main/java/ru/l3r8y/parser/Declaration.java
@@ -1,13 +1,44 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023. Ivanchuck Ivan.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package ru.l3r8y.parser;
 
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import lombok.RequiredArgsConstructor;
 
+/*
+ * @todo #85 Create a reasonable test case.
+ *  Let's create a reasonable test case for Declaration#declare.
+ *  Possibly it should check if Class is type of ClassOrInterfaceDeclaration.
+ *  Don't remove this puzzle until its done.
+ */
 /**
  * Class declaration.
  *
  * @since 0.3.6
  */
+@RequiredArgsConstructor
 public final class Declaration implements CodeClass {
 
     /**
@@ -19,17 +50,6 @@ public final class Declaration implements CodeClass {
      * Class.
      */
     private final Node clazz;
-
-    /**
-     * Ctor.
-     *
-     * @param cd code
-     * @param clzz class
-     */
-    public Declaration(final Code cd, final Node clzz) {
-        this.code = cd;
-        this.clazz = clzz;
-    }
 
     @Override
     public void declare() {

--- a/src/main/java/ru/l3r8y/parser/Declaration.java
+++ b/src/main/java/ru/l3r8y/parser/Declaration.java
@@ -57,4 +57,5 @@ public final class Declaration implements CodeClass {
             this.code.add((ClassOrInterfaceDeclaration) this.clazz);
         }
     }
+
 }

--- a/src/main/java/ru/l3r8y/parser/Default.java
+++ b/src/main/java/ru/l3r8y/parser/Default.java
@@ -53,4 +53,5 @@ public final class Default implements Code {
             new ParsedClassName(declaration.getNameAsString(), this.path)
         );
     }
+
 }

--- a/src/main/java/ru/l3r8y/parser/Default.java
+++ b/src/main/java/ru/l3r8y/parser/Default.java
@@ -1,0 +1,42 @@
+package ru.l3r8y.parser;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import ru.l3r8y.ClassName;
+
+/**
+ * Default code.
+ *
+ * @since 0.3.6
+ */
+public final class Default implements Code {
+
+    /**
+     * Names.
+     */
+    private final Collection<ClassName> accum;
+
+    /**
+     * Path.
+     */
+    private final Path path;
+
+    /**
+     * Ctor.
+     *
+     * @param names names
+     * @param pth path
+     */
+    public Default(final Collection<ClassName> names, final Path pth) {
+        this.accum = names;
+        this.path = pth;
+    }
+
+    @Override
+    public void add(final ClassOrInterfaceDeclaration declaration) {
+        this.accum.add(
+            new ParsedClassName(declaration.getNameAsString(), this.path)
+        );
+    }
+}

--- a/src/main/java/ru/l3r8y/parser/Default.java
+++ b/src/main/java/ru/l3r8y/parser/Default.java
@@ -1,8 +1,32 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023. Ivanchuck Ivan.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package ru.l3r8y.parser;
 
 import java.nio.file.Path;
 import java.util.Collection;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import lombok.RequiredArgsConstructor;
 import ru.l3r8y.ClassName;
 
 /**
@@ -10,6 +34,7 @@ import ru.l3r8y.ClassName;
  *
  * @since 0.3.6
  */
+@RequiredArgsConstructor
 public final class Default implements Code {
 
     /**
@@ -21,17 +46,6 @@ public final class Default implements Code {
      * Path.
      */
     private final Path path;
-
-    /**
-     * Ctor.
-     *
-     * @param names names
-     * @param pth path
-     */
-    public Default(final Collection<ClassName> names, final Path pth) {
-        this.accum = names;
-        this.path = pth;
-    }
 
     @Override
     public void add(final ClassOrInterfaceDeclaration declaration) {

--- a/src/main/java/ru/l3r8y/parser/Default.java
+++ b/src/main/java/ru/l3r8y/parser/Default.java
@@ -23,9 +23,9 @@
  */
 package ru.l3r8y.parser;
 
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import java.nio.file.Path;
 import java.util.Collection;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import lombok.RequiredArgsConstructor;
 import ru.l3r8y.ClassName;
 

--- a/src/main/java/ru/l3r8y/parser/IgnoresSuppressed.java
+++ b/src/main/java/ru/l3r8y/parser/IgnoresSuppressed.java
@@ -1,34 +1,49 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023. Ivanchuck Ivan.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package ru.l3r8y.parser;
 
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-
 import java.util.List;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import lombok.RequiredArgsConstructor;
 
 /**
  * Code that ignores suppressed classes.
  *
  * @since 0.3.6
  */
+@RequiredArgsConstructor
 public final class IgnoresSuppressed implements Code {
 
     /**
      * Origin.
      */
     private final Code origin;
-    private final List<String> all;
 
     /**
-     * Ctor.
-     *
-     * @param code origin
+     * All checks.
      */
-    public IgnoresSuppressed(
-        final Code code,
-        final List<String> chks
-    ) {
-        this.origin = code;
-        this.all = chks;
-    }
+    private final List<String> all;
 
     @Override
     public void add(final ClassOrInterfaceDeclaration declaration) {

--- a/src/main/java/ru/l3r8y/parser/IgnoresSuppressed.java
+++ b/src/main/java/ru/l3r8y/parser/IgnoresSuppressed.java
@@ -60,4 +60,5 @@ public final class IgnoresSuppressed implements Code {
             this.origin.add(declaration);
         }
     }
+
 }

--- a/src/main/java/ru/l3r8y/parser/IgnoresSuppressed.java
+++ b/src/main/java/ru/l3r8y/parser/IgnoresSuppressed.java
@@ -23,8 +23,8 @@
  */
 package ru.l3r8y.parser;
 
-import java.util.List;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 /**

--- a/src/main/java/ru/l3r8y/parser/IgnoresSuppressed.java
+++ b/src/main/java/ru/l3r8y/parser/IgnoresSuppressed.java
@@ -1,0 +1,48 @@
+package ru.l3r8y.parser;
+
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+
+import java.util.List;
+
+/**
+ * Code that ignores suppressed classes.
+ *
+ * @since 0.3.6
+ */
+public final class IgnoresSuppressed implements Code {
+
+    /**
+     * Origin.
+     */
+    private final Code origin;
+    private final List<String> all;
+
+    /**
+     * Ctor.
+     *
+     * @param code origin
+     */
+    public IgnoresSuppressed(
+        final Code code,
+        final List<String> chks
+    ) {
+        this.origin = code;
+        this.all = chks;
+    }
+
+    @Override
+    public void add(final ClassOrInterfaceDeclaration declaration) {
+        final List<String> suppressed = new SuppressedChecks(declaration).value();
+        if (suppressed.isEmpty()) {
+            this.origin.add(declaration);
+        }
+        if (
+            !new IsSuppressed(
+                suppressed,
+                this.all
+            ).value()
+        ) {
+            this.origin.add(declaration);
+        }
+    }
+}

--- a/src/main/java/ru/l3r8y/parser/IsSuppressed.java
+++ b/src/main/java/ru/l3r8y/parser/IsSuppressed.java
@@ -23,9 +23,11 @@
  */
 package ru.l3r8y.parser;
 
+import java.util.HashSet;
 import java.util.List;
 import lombok.SneakyThrows;
 import org.cactoos.Scalar;
+import org.cactoos.list.ListOf;
 
 /**
  * Is check suppressed?
@@ -42,35 +44,39 @@ public final class IsSuppressed implements Scalar<Boolean> {
     /**
      * Suppressions.
      */
-    private final Scalar<List<String>> suppressions;
+    private final List<String> suppressions;
 
     /**
-     * Check to suppress.
+     * Checks to suppress.
      */
-    private final String check;
+    private final List<String> checks;
 
     /**
      * Ctor.
+     *
      * @param spprs Suppressions
-     * @param chk Check to suppress
+     * @param chks  Checks to suppress
      */
     public IsSuppressed(
-        final Scalar<List<String>> spprs,
-        final String chk
+        final List<String> spprs,
+        final List<String> chks
     ) {
         this.suppressions = spprs;
-        this.check = chk;
+        this.checks = chks;
     }
 
     @Override
     @SneakyThrows
     public Boolean value() {
-        return this.suppressions.value().contains(
-            String.format(
-                "%s.%s",
-                IsSuppressed.PREFIX,
-                this.check
+        final List<String> suppressed = this.suppressions;
+        final List<String> prefixed = new ListOf<>();
+        this.checks.forEach(
+            check -> prefixed.add(
+                String.format("%s.%s", IsSuppressed.PREFIX, check)
             )
         );
+        System.out.println(String.format("All: %s", prefixed));
+        System.out.println(String.format("S: %s", suppressed));
+        return new HashSet<>(prefixed).containsAll(suppressed);
     }
 }

--- a/src/main/java/ru/l3r8y/parser/IsSuppressed.java
+++ b/src/main/java/ru/l3r8y/parser/IsSuppressed.java
@@ -25,6 +25,7 @@ package ru.l3r8y.parser;
 
 import java.util.HashSet;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.cactoos.Scalar;
 import org.cactoos.list.ListOf;
@@ -34,6 +35,7 @@ import org.cactoos.list.ListOf;
  *
  * @since 0.2.6
  */
+@RequiredArgsConstructor
 public final class IsSuppressed implements Scalar<Boolean> {
 
     /**
@@ -51,32 +53,16 @@ public final class IsSuppressed implements Scalar<Boolean> {
      */
     private final List<String> checks;
 
-    /**
-     * Ctor.
-     *
-     * @param spprs Suppressions
-     * @param chks  Checks to suppress
-     */
-    public IsSuppressed(
-        final List<String> spprs,
-        final List<String> chks
-    ) {
-        this.suppressions = spprs;
-        this.checks = chks;
-    }
-
     @Override
     @SneakyThrows
     public Boolean value() {
-        final List<String> suppressed = this.suppressions;
         final List<String> prefixed = new ListOf<>();
         this.checks.forEach(
             check -> prefixed.add(
                 String.format("%s.%s", IsSuppressed.PREFIX, check)
             )
         );
-        System.out.println(String.format("All: %s", prefixed));
-        System.out.println(String.format("S: %s", suppressed));
-        return new HashSet<>(prefixed).containsAll(suppressed);
+        return new HashSet<>(prefixed).containsAll(this.suppressions);
     }
+
 }

--- a/src/main/java/ru/l3r8y/parser/SuppressedChecks.java
+++ b/src/main/java/ru/l3r8y/parser/SuppressedChecks.java
@@ -40,11 +40,6 @@ import org.cactoos.list.ListOf;
  *  this object will just aggregate all suppressions.
  *  Don't forget to remove this puzzle.
  *
- * @todo #38 This class lacks off unit testing.
- *  ClassOrInterfaceDeclaration can't be provided in tests,
- *  so we need to do something with it in order to create small
- *  unit tests for this and other classes (see puzzle above).
- *  Don't forget to remove this puzzle.
  * */
 /**
  * Suppressed checks.

--- a/src/test/java/ru/l3r8y/extensions/ManySuppressionsDeclaration.java
+++ b/src/test/java/ru/l3r8y/extensions/ManySuppressionsDeclaration.java
@@ -1,0 +1,77 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023. Ivanchuck Ivan.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package ru.l3r8y.extensions;
+
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.expr.ArrayInitializerExpr;
+import com.github.javaparser.ast.expr.Name;
+import com.github.javaparser.ast.expr.SimpleName;
+import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+import java.util.Objects;
+
+/**
+ * JUnit extension with Java class that have many suppressions.
+ *
+ * @since 0.3.6
+ */
+public final class ManySuppressionsDeclaration implements ParameterResolver {
+
+    @Override
+    public boolean supportsParameter(
+        final ParameterContext pctx,
+        final ExtensionContext ectx
+    ) {
+        return Objects.equals(
+            pctx.getParameter().getType(), ClassOrInterfaceDeclaration.class
+        );
+    }
+
+    @Override
+    public Object resolveParameter(
+        final ParameterContext pctx,
+        final ExtensionContext ectx
+    ) {
+        final ClassOrInterfaceDeclaration declaration =
+            new ClassOrInterfaceDeclaration();
+        declaration.setName(new SimpleName("MutableParser"));
+        declaration.addAnnotation(
+            new SingleMemberAnnotationExpr(
+                new Name("SuppressWarnings"),
+                new ArrayInitializerExpr(
+                    new NodeList<>(
+                        new StringLiteralExpr("OOP.MutableStateCheck"),
+                        new StringLiteralExpr("OOP.ErSuffixCheck")
+                    )
+                )
+            )
+        );
+        return declaration;
+    }
+}

--- a/src/test/java/ru/l3r8y/extensions/ManySuppressionsDeclaration.java
+++ b/src/test/java/ru/l3r8y/extensions/ManySuppressionsDeclaration.java
@@ -30,11 +30,10 @@ import com.github.javaparser.ast.expr.Name;
 import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
+import java.util.Objects;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolver;
-
-import java.util.Objects;
 
 /**
  * JUnit extension with Java class that have many suppressions.

--- a/src/test/java/ru/l3r8y/extensions/ParserDeclaration.java
+++ b/src/test/java/ru/l3r8y/extensions/ParserDeclaration.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023. Ivanchuck Ivan.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package ru.l3r8y.extensions;
+
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.expr.Name;
+import com.github.javaparser.ast.expr.SimpleName;
+import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import java.util.Objects;
+
+/**
+ * JUnit extension with Parser Java class declaration.
+ * @since 0.3.6
+ */
+public final class ParserDeclaration implements ParameterResolver {
+
+    @Override
+    public boolean supportsParameter(
+        final ParameterContext pctx,
+        final ExtensionContext ectx
+    ) {
+        return Objects.equals(
+            pctx.getParameter().getType(), ClassOrInterfaceDeclaration.class
+        );
+    }
+
+    @Override
+    public Object resolveParameter(
+        final ParameterContext pctx,
+        final ExtensionContext ectx
+    ) {
+        final ClassOrInterfaceDeclaration declaration =
+            new ClassOrInterfaceDeclaration();
+        declaration.setName(new SimpleName("Parser"));
+        declaration.addAnnotation(
+            new SingleMemberAnnotationExpr(
+                new Name("SuppressWarnings"),
+                new StringLiteralExpr("OOP.ErSuffixCheck")
+            )
+        );
+        return declaration;
+    }
+}

--- a/src/test/java/ru/l3r8y/extensions/ParserDeclaration.java
+++ b/src/test/java/ru/l3r8y/extensions/ParserDeclaration.java
@@ -28,10 +28,10 @@ import com.github.javaparser.ast.expr.Name;
 import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
+import java.util.Objects;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolver;
-import java.util.Objects;
 
 /**
  * JUnit extension with Parser Java class declaration.

--- a/src/test/java/ru/l3r8y/extensions/SuppressedLongClassName.java
+++ b/src/test/java/ru/l3r8y/extensions/SuppressedLongClassName.java
@@ -23,12 +23,12 @@
  */
 package ru.l3r8y.extensions;
 
+import java.nio.file.Path;
+import java.util.Objects;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import ru.l3r8y.fake.FakeClass;
-import java.nio.file.Path;
-import java.util.Objects;
 
 /**
  * JUnit extension with suppressed {@link ru.l3r8y.rule.LongClassNameCheck}.

--- a/src/test/java/ru/l3r8y/extensions/SuppressedLongClassName.java
+++ b/src/test/java/ru/l3r8y/extensions/SuppressedLongClassName.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023. Ivanchuck Ivan.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package ru.l3r8y.extensions;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import ru.l3r8y.fake.FakeClass;
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * JUnit extension with suppressed {@link ru.l3r8y.rule.LongClassNameCheck}.
+ * @since 0.3.6
+ */
+public final class SuppressedLongClassName implements ParameterResolver {
+
+    @Override
+    public boolean supportsParameter(
+        final ParameterContext pctx,
+        final ExtensionContext ectx
+    ) {
+        return Objects.equals(pctx.getParameter().getType(), Path.class);
+    }
+
+    @Override
+    public Object resolveParameter(
+        final ParameterContext pctx,
+        final ExtensionContext ectx
+    ) {
+        return new FakeClass("VeryLongClassName.java").asPath();
+    }
+}

--- a/src/test/java/ru/l3r8y/parser/ClassNamesTest.java
+++ b/src/test/java/ru/l3r8y/parser/ClassNamesTest.java
@@ -44,7 +44,7 @@ final class ClassNamesTest {
 
     @Test
     @ExtendWith(InvalidClass.class)
-    void parsesClassNamesInRightFormat(final Path clazz) {
+    void parsesInvalidClassNamesInRightFormat(final Path clazz) {
         final String name = new ListOf<>(
             new ClassNames(clazz).all()
         ).get(0).value();

--- a/src/test/java/ru/l3r8y/parser/DeclarationTest.java
+++ b/src/test/java/ru/l3r8y/parser/DeclarationTest.java
@@ -23,33 +23,48 @@
  */
 package ru.l3r8y.parser;
 
-import com.github.javaparser.ast.Node;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import lombok.RequiredArgsConstructor;
+import com.github.javaparser.StaticJavaParser;
+import org.cactoos.list.ListOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import ru.l3r8y.ClassName;
+import ru.l3r8y.extensions.ValidClass;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
 
 /**
- * Class declaration.
+ * Test case for {@link Declaration}.
  *
  * @since 0.3.6
  */
-@RequiredArgsConstructor
-public final class Declaration implements CodeClass {
+final class DeclarationTest {
 
-    /**
-     * Origin.
-     */
-    private final Code code;
-
-    /**
-     * Class.
-     */
-    private final Node clazz;
-
-    @Override
-    public void declare() {
-        if (this.clazz instanceof ClassOrInterfaceDeclaration) {
-            this.code.add((ClassOrInterfaceDeclaration) this.clazz);
-        }
+    @Test
+    @ExtendWith(ValidClass.class)
+    void declaresClass(final Path clazz) throws IOException {
+        final List<ClassName> names = new ListOf<>();
+        StaticJavaParser.parse(clazz)
+            .getChildNodes()
+            .forEach(
+                node -> new Declaration(
+                    new Default(names, clazz),
+                    node
+                ).declare()
+            );
+        final String name = names.get(0).value();
+        final String expected = "ValidClass";
+        MatcherAssert.assertThat(
+            String.format(
+                "Class name %s does not match with expected one %s",
+                name,
+                expected
+            ),
+            name,
+            new IsEqual<>(expected)
+        );
     }
 
 }

--- a/src/test/java/ru/l3r8y/parser/DeclarationTest.java
+++ b/src/test/java/ru/l3r8y/parser/DeclarationTest.java
@@ -24,6 +24,9 @@
 package ru.l3r8y.parser;
 
 import com.github.javaparser.StaticJavaParser;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
@@ -31,9 +34,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import ru.l3r8y.ClassName;
 import ru.l3r8y.extensions.ValidClass;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.List;
 
 /**
  * Test case for {@link Declaration}.

--- a/src/test/java/ru/l3r8y/parser/DefaultTest.java
+++ b/src/test/java/ru/l3r8y/parser/DefaultTest.java
@@ -1,0 +1,90 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023. Ivanchuck Ivan.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package ru.l3r8y.parser;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import org.cactoos.list.ListOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import ru.l3r8y.ClassName;
+import ru.l3r8y.extensions.InvalidClass;
+import ru.l3r8y.extensions.ValidClass;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Test case for {@link Default}.
+ *
+ * @since 0.3.6
+ */
+final class DefaultTest {
+
+    @Test
+    @ExtendWith(ValidClass.class)
+    void addsToAccum(final Path clazz) throws IOException {
+        final List<ClassName> accum = new ListOf<>();
+        StaticJavaParser.parse(clazz)
+            .getChildNodes()
+            .forEach(
+                node -> new Default(accum, clazz)
+                    .add((ClassOrInterfaceDeclaration) node)
+            );
+        final String expected = "ValidClass";
+        final String name = accum.get(0).value();
+        MatcherAssert.assertThat(
+            String.format(
+                "Class %s does not matches with expected one %s",
+                name, expected
+            ),
+            name,
+            new IsEqual<>(expected)
+        );
+    }
+
+    @Test
+    @ExtendWith(InvalidClass.class)
+    void addsEvenInvalidClass(final Path clazz) throws IOException {
+        final List<ClassName> accum = new ListOf<>();
+        StaticJavaParser.parse(clazz)
+            .getChildNodes()
+            .forEach(
+                node -> new Default(accum, clazz)
+                    .add((ClassOrInterfaceDeclaration) node)
+            );
+        final String expected = "InvalidClass";
+        final String name = accum.get(0).value();
+        MatcherAssert.assertThat(
+            String.format(
+                "Class %s does not matches with expected one %s",
+                name, expected
+            ),
+            name,
+            new IsEqual<>(expected)
+        );
+    }
+}

--- a/src/test/java/ru/l3r8y/parser/DefaultTest.java
+++ b/src/test/java/ru/l3r8y/parser/DefaultTest.java
@@ -25,6 +25,9 @@ package ru.l3r8y.parser;
 
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
@@ -33,9 +36,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import ru.l3r8y.ClassName;
 import ru.l3r8y.extensions.InvalidClass;
 import ru.l3r8y.extensions.ValidClass;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.List;
 
 /**
  * Test case for {@link Default}.

--- a/src/test/java/ru/l3r8y/parser/IgnoresSuppressedTest.java
+++ b/src/test/java/ru/l3r8y/parser/IgnoresSuppressedTest.java
@@ -115,4 +115,5 @@ final class IgnoresSuppressedTest {
             new IsEqual<>(expected)
         );
     }
+
 }

--- a/src/test/java/ru/l3r8y/parser/IgnoresSuppressedTest.java
+++ b/src/test/java/ru/l3r8y/parser/IgnoresSuppressedTest.java
@@ -25,6 +25,10 @@ package ru.l3r8y.parser;
 
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
@@ -33,10 +37,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import ru.l3r8y.ClassName;
 import ru.l3r8y.extensions.InvalidClass;
 import ru.l3r8y.extensions.ParserDeclaration;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
 
 /**
  * Test case for {@link IgnoresSuppressed}.

--- a/src/test/java/ru/l3r8y/parser/IgnoresSuppressedTest.java
+++ b/src/test/java/ru/l3r8y/parser/IgnoresSuppressedTest.java
@@ -66,6 +66,29 @@ final class IgnoresSuppressedTest {
     }
 
     @Test
+    @ExtendWith(ParserDeclaration.class)
+    void addsIfSuppressionsAreInvalid(
+        final ClassOrInterfaceDeclaration declaration
+    ) {
+        final List<ClassName> accum = new ListOf<>();
+        new IgnoresSuppressed(
+            new Default(accum, Paths.get("test")),
+            new ListOf<>()
+        ).add(declaration);
+        final String expected = "Parser";
+        final String name = accum.get(0).value();
+        MatcherAssert.assertThat(
+            String.format(
+                "Class %s does not matches with expected one %s",
+                name,
+                expected
+            ),
+            name,
+            new IsEqual<>(expected)
+        );
+    }
+
+    @Test
     @ExtendWith(InvalidClass.class)
     void addsInvalid(final Path clazz) throws IOException {
         final List<ClassName> accum = new ListOf<>();

--- a/src/test/java/ru/l3r8y/parser/IgnoresSuppressedTest.java
+++ b/src/test/java/ru/l3r8y/parser/IgnoresSuppressedTest.java
@@ -1,0 +1,105 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023. Ivanchuck Ivan.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package ru.l3r8y.parser;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.expr.Name;
+import com.github.javaparser.ast.expr.SimpleName;
+import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import org.cactoos.list.ListOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import ru.l3r8y.ClassName;
+import ru.l3r8y.extensions.InvalidClass;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+/**
+ * Test case for {@link IgnoresSuppressed}.
+ *
+ * @since 0.3.6
+ */
+final class IgnoresSuppressedTest {
+
+    @Test
+    void ignoresSuppressed() throws IOException {
+        final List<ClassName> accum = new ListOf<>();
+        final ClassOrInterfaceDeclaration declaration = new ClassOrInterfaceDeclaration();
+        declaration.setName(new SimpleName("MutableParser"));
+        declaration.addAnnotation(
+            new SingleMemberAnnotationExpr(
+                new Name("SuppressWarnings"),
+                new StringLiteralExpr("OOP.ErSuffixCheck")
+            )
+        );
+        new IgnoresSuppressed(
+            new Default(accum, Paths.get("test")),
+            new ListOf<>(
+                "ErSuffixCheck"
+            )
+        ).add(declaration);
+        MatcherAssert.assertThat(
+            String.format(
+                "Class %s does not ignored, but it should",
+                declaration.getNameAsString()
+            ),
+            accum.isEmpty(),
+            new IsEqual<>(true)
+        );
+    }
+
+    @Test
+    @ExtendWith(InvalidClass.class)
+    void addsInvalid(final Path clazz) throws IOException {
+        final List<ClassName> accum = new ListOf<>();
+        StaticJavaParser.parse(clazz)
+            .getChildNodes()
+            .forEach(
+                node ->
+                    new IgnoresSuppressed(
+                        new Default(accum, clazz),
+                        new ListOf<>(
+                            "ErSuffixCheck",
+                            "MutableStateCheck"
+                        )
+                    ).add((ClassOrInterfaceDeclaration) node)
+            );
+        final String expected = "InvalidClass";
+        final String name = accum.get(0).value();
+        MatcherAssert.assertThat(
+            String.format(
+                "Class %s does not matches with expected one %s",
+                name, expected
+            ),
+            name,
+            new IsEqual<>(expected)
+        );
+    }
+}

--- a/src/test/java/ru/l3r8y/parser/IgnoresSuppressedTest.java
+++ b/src/test/java/ru/l3r8y/parser/IgnoresSuppressedTest.java
@@ -49,7 +49,7 @@ import java.util.List;
 final class IgnoresSuppressedTest {
 
     @Test
-    void ignoresSuppressed() throws IOException {
+    void ignoresSuppressed() {
         final List<ClassName> accum = new ListOf<>();
         final ClassOrInterfaceDeclaration declaration = new ClassOrInterfaceDeclaration();
         declaration.setName(new SimpleName("MutableParser"));

--- a/src/test/java/ru/l3r8y/parser/IsSuppressedTest.java
+++ b/src/test/java/ru/l3r8y/parser/IsSuppressedTest.java
@@ -49,8 +49,8 @@ final class IsSuppressedTest {
                 checks
             ),
             new IsSuppressed(
-                () -> checks,
-                check
+                checks,
+                new ListOf<>(check)
             ).value(),
             new IsEqual<>(true)
         );
@@ -67,8 +67,8 @@ final class IsSuppressedTest {
                 checks
             ),
             new IsSuppressed(
-                () -> checks,
-                check
+                checks,
+                new ListOf<>(check)
             ).value(),
             new IsEqual<>(false)
         );

--- a/src/test/java/ru/l3r8y/parser/SuppressedChecksTest.java
+++ b/src/test/java/ru/l3r8y/parser/SuppressedChecksTest.java
@@ -25,6 +25,7 @@ package ru.l3r8y.parser;
 
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.expr.SimpleName;
+import java.util.List;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
@@ -32,7 +33,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import ru.l3r8y.extensions.ManySuppressionsDeclaration;
 import ru.l3r8y.extensions.ParserDeclaration;
-import java.util.List;
 
 /**
  * Test case for {@link SuppressedChecks}.

--- a/src/test/java/ru/l3r8y/rule/LongClassNameCheckTest.java
+++ b/src/test/java/ru/l3r8y/rule/LongClassNameCheckTest.java
@@ -29,6 +29,8 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import ru.l3r8y.extensions.LongNamedClass;
+import ru.l3r8y.extensions.ManySuppressions;
+import ru.l3r8y.extensions.SuppressedLongClassName;
 import ru.l3r8y.extensions.ValidClass;
 
 /**
@@ -54,6 +56,16 @@ final class LongClassNameCheckTest {
         MatcherAssert.assertThat(
             "Build is not successed as expected",
             new CompositeClassName(clazz, 13).complaints(),
+            Matchers.empty()
+        );
+    }
+
+    @Test
+    @ExtendWith(SuppressedLongClassName.class)
+    void passesWhenSuppressed(final Path clazz) {
+        MatcherAssert.assertThat(
+            "Suppressed class has complaints, but it shouldn't",
+            new CompositeClassName(clazz, 12).complaints(),
             Matchers.empty()
         );
     }

--- a/src/test/java/ru/l3r8y/rule/LongClassNameCheckTest.java
+++ b/src/test/java/ru/l3r8y/rule/LongClassNameCheckTest.java
@@ -29,7 +29,6 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import ru.l3r8y.extensions.LongNamedClass;
-import ru.l3r8y.extensions.ManySuppressions;
 import ru.l3r8y.extensions.SuppressedLongClassName;
 import ru.l3r8y.extensions.ValidClass;
 

--- a/src/test/java/ru/l3r8y/rule/MethodChangesStateTest.java
+++ b/src/test/java/ru/l3r8y/rule/MethodChangesStateTest.java
@@ -28,7 +28,6 @@
 package ru.l3r8y.rule;
 
 import java.nio.file.Path;
-
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;

--- a/src/test/java/ru/l3r8y/rule/MethodChangesStateTest.java
+++ b/src/test/java/ru/l3r8y/rule/MethodChangesStateTest.java
@@ -28,6 +28,7 @@
 package ru.l3r8y.rule;
 
 import java.nio.file.Path;
+
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import ru.l3r8y.extensions.CaseWithoutThis;
 import ru.l3r8y.extensions.InvalidClass;
+import ru.l3r8y.extensions.ManySuppressions;
 import ru.l3r8y.extensions.Marked;
 import ru.l3r8y.extensions.ValidClass;
 
@@ -81,6 +83,16 @@ final class MethodChangesStateTest {
     void passesWhenMutableMarked(final Path clazz) {
         MatcherAssert.assertThat(
             "Marked class wasn't checked",
+            new AssigmentCheck(clazz).complaints(),
+            Matchers.empty()
+        );
+    }
+
+    @Test
+    @ExtendWith(ManySuppressions.class)
+    void passesWhenManySuppressed(final Path clazz) {
+        MatcherAssert.assertThat(
+            "Class with many suppressions is checked, but it shouldn't",
             new AssigmentCheck(clazz).complaints(),
             Matchers.empty()
         );

--- a/src/test/resources/VeryLongClassName.java
+++ b/src/test/resources/VeryLongClassName.java
@@ -1,0 +1,3 @@
+@SuppressWarnings("OOP.LongClassNameCheck")
+class VeryLongClassName {
+}


### PR DESCRIPTION
closes #85

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a new class `VeryLongClassName` in two different locations with different annotations.
- Added a new configuration in `pom.xml`.
- Renamed the method `parsesClassNamesInRightFormat` to `parsesInvalidClassNamesInRightFormat` in `ClassNamesTest`.
- Modified the imports in `IsSuppressedTest`.
- Added two new test methods in `LongClassNameCheckTest` and `MethodChangesStateTest`.
- Added a new interface `CodeClass` and implemented it in `CodeClass.java`.
- Added a new interface `Code` and implemented it in `Code.java`.
- Added a new class `Declaration` and implemented `CodeClass` in `Declaration.java`.
- Added a new class `Default` and implemented `Code` in `Default.java`.
- Added a new interface `Code` and implemented it in `Code.java`.
- Added a new class `Default` and implemented `Code` in `Default.java`.

> The following files were skipped due to too many changes: `src/main/java/ru/l3r8y/parser/Default.java`, `src/main/java/ru/l3r8y/parser/ClassNames.java`, `src/main/java/ru/l3r8y/parser/IgnoresSuppressed.java`, `src/test/java/ru/l3r8y/extensions/SuppressedLongClassName.java`, `src/test/java/ru/l3r8y/parser/DeclarationTest.java`, `src/test/java/ru/l3r8y/extensions/ParserDeclaration.java`, `src/test/java/ru/l3r8y/extensions/ManySuppressionsDeclaration.java`, `src/test/java/ru/l3r8y/parser/DefaultTest.java`, `src/test/java/ru/l3r8y/parser/SuppressedChecksTest.java`, `src/test/java/ru/l3r8y/parser/IgnoresSuppressedTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->