### PR TITLE
chore: reports-check 0.1.1

### DIFF
--- a/.github/workflows/reports-check.yml
+++ b/.github/workflows/reports-check.yml
@@ -1,0 +1,14 @@
+---
+name: reports-check
+on:
+ issues:
+   types: opened
+jobs:
+  check:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tracehubpm/reports-check-action@0.1.1-deepinfra
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          deepinfra_token: ${{ secrets.DEEPINFRA_TOKEN }}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a GitHub Actions workflow `reports-check` that runs on opened issues to check reports using `tracehubpm/reports-check-action`.

### Detailed summary
- Added GitHub Actions workflow `reports-check.yml`
- Triggered on opened issues
- Utilizes `tracehubpm/reports-check-action@0.1.1-deepinfra`
- Requires `GITHUB_TOKEN` and `DEEPINFRA_TOKEN` secrets

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->